### PR TITLE
incorporate Aphrodite into ExecJSRenderer.render

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 * * *
 
+NOTE: This is Flexport's fork of react-rails. It is forked from version 1.8.2,
+and modifies `ExecJSRenderer`'s `render` method to allow Aphrodite to work
+properly during server-side rendering.
+
 # react-rails
 
 

--- a/lib/react/server_rendering/exec_js_renderer.rb
+++ b/lib/react/server_rendering/exec_js_renderer.rb
@@ -15,9 +15,13 @@ module React
         js_code = <<-JS
           (function () {
             #{before_render(component_name, props, prerender_options)}
-            var result = ReactDOMServer.#{render_function}(React.createElement(#{component_name}, #{props}));
+            const staticContent = StyleSheetServer.renderStatic(function() {
+              return ReactDOMServer.#{render_function}(React.createElement(#{component_name}, #{props}));
+            });
             #{after_render(component_name, props, prerender_options)}
-            return result;
+            return (
+             "<div><style>" + staticContent.css.content + "</style>" + staticContent.html + "</div>"
+            );
           })()
         JS
         @context.eval(js_code).html_safe


### PR DESCRIPTION
```
This is Flexport's fork of react-rails. It is forked from version 1.8.2,
and modifies `ExecJSRenderer`'s `render` method to allow Aphrodite to work
properly during server-side rendering.
```