### PR TITLE
Log when you can't mount the app

### DIFF
--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -56,7 +56,7 @@
         var constructor = window[className];
 
         if (typeof constructor === "undefined") {
-          if (!props.appFileName) {
+          if (!props || !props.appFileName) {
             throw new Error("Can't mount the app because window." + className + " is undefined");  
           }
           throw new Error("Can't mount the app because " + props.appFileName + " was not loaded. ");

--- a/lib/assets/javascripts/react_ujs_mount.js
+++ b/lib/assets/javascripts/react_ujs_mount.js
@@ -42,30 +42,6 @@
       }
     },
 
-    // Get the constructor for a className
-    getConstructor: function(className) {
-      // Assume className is simple and can be found at top-level (window).
-      // Fallback to eval to handle cases like 'My.React.ComponentName'.
-      // Also, try to gracefully import Babel 6 style default exports
-      //
-      var constructor;
-
-      // Try to access the class globally first
-      constructor = window[className];
-
-      // If that didn't work, try eval
-      if (!constructor) {
-        constructor = eval.call(window, className);
-      }
-
-      // Lastly, if there is a default attribute try that
-      if (constructor && constructor.default) {
-        constructor = constructor.default;
-      }
-
-      return constructor;
-    },
-
     // Within `searchSelector`, find nodes which should have React components
     // inside them, and mount them with their props.
     mountComponents: function(searchSelector) {
@@ -73,19 +49,20 @@
 
       for (var i = 0; i < nodes.length; ++i) {
         var node = nodes[i];
-        var className = node.getAttribute(window.ReactRailsUJS.CLASS_NAME_ATTR);
-        var constructor = this.getConstructor(className);
         var propsJson = node.getAttribute(window.ReactRailsUJS.PROPS_ATTR);
         var props = propsJson && JSON.parse(propsJson);
 
-        if (typeof(constructor) === "undefined") {
-          var message = "Cannot find component: '" + className + "'"
-          if (console && console.log) { console.log("%c[react-rails] %c" + message + " for element", "font-weight: bold", "", node) }
-          var error = new Error(message + ". Make sure your component is globally available to render.")
-          throw error
-        } else {
-          ReactDOM.render(React.createElement(constructor, props), node);
+        var className = node.getAttribute(window.ReactRailsUJS.CLASS_NAME_ATTR);
+        var constructor = window[className];
+
+        if (typeof constructor === "undefined") {
+          if (!props.appFileName) {
+            throw new Error("Can't mount the app because window." + className + " is undefined");  
+          }
+          throw new Error("Can't mount the app because " + props.appFileName + " was not loaded. ");
         }
+
+        ReactDOM.render(React.createElement(constructor, props), node);
       }
     },
 


### PR DESCRIPTION
Sometimes we 404 when requesting the app code. In these cases `constructor = eval.call(window, className);` would throw an exception.

Try and be a bit more descriptive, logging file name of the file that 404'ed